### PR TITLE
Add plugin for discovery

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,9 @@
+=== Main
+
+* 1 bug fix:
+
+  * Add plugin for discovery
+
 === 5.27.0 / 2025-12-18
 
 * No changes

--- a/lib/minitest/mock_plugin.rb
+++ b/lib/minitest/mock_plugin.rb
@@ -1,0 +1,1 @@
+require_relative 'mock'


### PR DESCRIPTION
Mock has been extracted into a separate gem, however, the plugin code was missing and therefore an explicit `require` necessary for it to work. This adds the missing plugin and allows Minitest to discover Mock when bundled.

Closes #5